### PR TITLE
Remove duplicated code in mockVoidMethod

### DIFF
--- a/src/classes/fflib_ApexMocks.cls
+++ b/src/classes/fflib_ApexMocks.cls
@@ -195,27 +195,9 @@ public with sharing class fflib_ApexMocks
 	 */
 	public void mockVoidMethod(Object mockInstance, String methodName, List<Type> methodArgTypes, List<Object> methodArgValues)
 	{
-		fflib_QualifiedMethod qm = new fflib_QualifiedMethod(extractTypeName(mockInstance), methodName, methodArgTypes);
-		fflib_MethodArgValues argValues = new fflib_MethodArgValues(methodArgValues);
-		
-		if (Verifying)
-		{
-			verifyMethodCall(qm, argValues);
-		}
-		else if (Stubbing)
-		{
-			prepareMethodReturnValue(qm, argValues).thenThrow(DoThrowWhenException);
-		}
-		else
-		{
-			recordMethod(qm, argValues);
-			
-			fflib_MethodReturnValue methodReturnValue = getMethodReturnValue(qm, argValues);
-			if (methodReturnValue != null && methodReturnValue.ReturnValue instanceof Exception)
-			{
-				throw ((Exception) methodReturnValue.ReturnValue);
-			}
-		}
+		//Ideally, we would supersede all calls to mockVoidMethod with mockNonVoidMethod and ignore the return value.
+		//However, retaining mockVoidMethod for backwards compatibility.
+		mockNonVoidMethod(mockInstance, methodName, methodArgTypes, methodArgValues);
 	}
 
 	/**
@@ -237,7 +219,8 @@ public with sharing class fflib_ApexMocks
 		}
 		else if (Stubbing)
 		{
-			prepareMethodReturnValue(qm, argValues);
+			prepareMethodReturnValue(qm, argValues).thenThrow(DoThrowWhenException);
+			DoThrowWhenException = null;
 			return null;
 		}
 		else

--- a/src/classes/fflib_MatcherDefinitions.cls
+++ b/src/classes/fflib_MatcherDefinitions.cls
@@ -886,7 +886,7 @@ public with sharing class fflib_MatcherDefinitions
 	{		
 		public Boolean matches(Object arg)
 		{
-            return (arg == null || arg instanceof String) ? String.isBlank((String)arg) : false;
+			return (arg == null || arg instanceof String) ? String.isBlank((String)arg) : false;
 		}
 	}
 
@@ -897,7 +897,7 @@ public with sharing class fflib_MatcherDefinitions
 	{		
 		public Boolean matches(Object arg)
 		{
-            return arg instanceof String ? String.isNotBlank((String)arg) : false;
+			return arg instanceof String ? String.isNotBlank((String)arg) : false;
 		}
 	}
 

--- a/src/classes/fflib_MatcherDefinitions.cls
+++ b/src/classes/fflib_MatcherDefinitions.cls
@@ -886,7 +886,7 @@ public with sharing class fflib_MatcherDefinitions
 	{		
 		public Boolean matches(Object arg)
 		{
-			return arg instanceof String ? String.isBlank((String)arg) : false;
+            return (arg == null || arg instanceof String) ? String.isBlank((String)arg) : false;
 		}
 	}
 
@@ -897,7 +897,7 @@ public with sharing class fflib_MatcherDefinitions
 	{		
 		public Boolean matches(Object arg)
 		{
-			return arg == NULL || arg instanceof String ? !String.isBlank((String)arg) : false;
+            return arg instanceof String ? String.isNotBlank((String)arg) : false;
 		}
 	}
 


### PR DESCRIPTION
Remove duplicated code. Also a precursor for stub API changes.