### PR TITLE
Explicit null handling in StringIsBlank and NotBlank

### DIFF
--- a/src/classes/fflib_MatcherDefinitions.cls
+++ b/src/classes/fflib_MatcherDefinitions.cls
@@ -886,7 +886,7 @@ public with sharing class fflib_MatcherDefinitions
 	{		
 		public Boolean matches(Object arg)
 		{
-			return (arg == null || arg instanceof String) ? String.isBlank((String)arg) : false;
+			return arg == null || (arg instanceof String ? String.isBlank((String)arg) : false);
 		}
 	}
 
@@ -897,7 +897,7 @@ public with sharing class fflib_MatcherDefinitions
 	{		
 		public Boolean matches(Object arg)
 		{
-			return arg instanceof String ? String.isNotBlank((String)arg) : false;
+			return (arg != NULL && arg instanceof String) ? String.isNotBlank((String)arg) : false;
 		}
 	}
 


### PR DESCRIPTION
This protects us from changes to the way the platform handles `null instanceof String` across different API versions.