### PR TITLE
AssertEquals with Matchers

### DIFF
--- a/src/classes/fflib_System.cls
+++ b/src/classes/fflib_System.cls
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
+ */
+
+/**
+ * @group Core
+ * Contains counterparts for helper methods in the native System class.
+ */
+
+public class fflib_System
+{
+	/**
+	 * Verifies that the supplied argument is meaningfully equivalent to the expected argument, as defined by its matcher.
+	 * See fflib_SystemTest for examples of usage.
+	 * @param ignoredRetval Dummy value, returned on registering an fflib_IMatcher.
+	 * @param value         The object instance upon which we are checking equality.
+	 */
+	public static void assertEquals(Object ignoredRetval, Object value)
+	{
+		assertEquals(ignoredRetval, value, null);
+	}
+
+	/**
+	 * Verifies that the supplied argument is meaningfully equivalent to the expected argument, as defined by its matcher.
+	 * See fflib_SystemTest for examples of usage.
+	 * @param ignoredRetval Dummy value, returned on registering an fflib_IMatcher.
+	 * @param value         The object instance upon which we are checking equality.
+	 * @param customAssertMessage Provides context or additional information for the assertion.
+	 */
+	public static void assertEquals(Object ignoredRetval, Object value, String customAssertMessage)
+	{
+		fflib_IMatcher matcher = null;
+		try
+		{
+			List<fflib_IMatcher> matchers = fflib_Match.getAndClearMatchers(1);
+			matcher = matchers[0];
+		}
+		catch (fflib_ApexMocks.ApexMocksException e)
+		{
+			throw new fflib_ApexMocks.ApexMocksException('fflib_System.assertEquals expects you to register exactly 1 fflib_IMatcher (typically through the helpers in fflib_Match).');
+		}
+		
+		if (!matcher.matches(value))
+		{
+			throw new fflib_ApexMocks.ApexMocksException(String.format('Expected : {0}, Actual: {1}{2}', new String[]{
+				String.valueOf(matcher),
+				String.valueOf(value),
+				String.isBlank(customAssertMessage) ? '' : (' -- ' + customAssertMessage)
+			}));
+		}
+	}
+}

--- a/src/classes/fflib_System.cls-meta.xml
+++ b/src/classes/fflib_System.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/fflib_SystemTest.cls
+++ b/src/classes/fflib_SystemTest.cls
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
+ */
+@IsTest
+private class fflib_SystemTest
+{
+	@IsTest
+	private static void assertEquals_WithNoMatchers_ShouldThrowException()
+	{
+		try
+		{
+			fflib_System.assertEquals('Test String', 'Test String');
+			System.assert(false, 'Expected exception');
+		}
+		catch (fflib_ApexMocks.ApexMocksException e)
+		{
+			System.assertEquals('fflib_System.assertEquals expects you to register exactly 1 fflib_IMatcher (typically through the helpers in fflib_Match).', e.getMessage());
+		}
+	}
+
+	@IsTest
+	private static void assertEquals_WithTooManyMatchers_ShouldThrowException()
+	{
+		//Register matchers prematurely
+		fflib_Match.stringStartsWith('Test S');
+		fflib_Match.stringEndsWith('t String');
+		fflib_Match.stringIsNotBlank();
+
+		try
+		{
+			fflib_System.assertEquals(fflib_Match.stringStartsWith('Test S'), 'Test String');
+			System.assert(false, 'Expected exception');
+		}
+		catch (fflib_ApexMocks.ApexMocksException e)
+		{
+			System.assertEquals('fflib_System.assertEquals expects you to register exactly 1 fflib_IMatcher (typically through the helpers in fflib_Match).', e.getMessage());
+		}
+	}
+
+	@IsTest
+	private static void assertEquals_WithMismatch_ShouldThrowException()
+	{
+		try
+		{
+			fflib_System.assertEquals(fflib_Match.stringStartsWith('Test X'), 'Test String');
+			System.assert(false, 'Expected exception');
+		}
+		catch (fflib_ApexMocks.ApexMocksException e)
+		{
+			String expected = 'Actual: Test String';
+			String actual = e.getMessage();
+			System.assert(actual.contains(expected), 'Expected: ' + expected + ', Actual: ' + actual);
+		}
+	}
+
+	@IsTest
+	private static void assertEquals_WithMatch_ShouldPass()
+	{
+		fflib_System.assertEquals(fflib_Match.stringStartsWith('Test S'), 'Test String');
+	}
+
+	@IsTest
+	private static void assertEquals_WithCombinedMatcher_ShouldPass()
+	{
+		fflib_System.assertEquals(fflib_Match.allOf(
+				fflib_Match.stringStartsWith('Test S'),
+				fflib_Match.stringEndsWith('t String'),
+				fflib_Match.stringIsNotBlank())
+			, 'Test String');
+	}
+
+	@IsTest
+	private static void assertEquals_WithCustomMessage_WithNoMatchers_ShouldThrowException()
+	{
+		try
+		{
+			fflib_System.assertEquals('Test String', 'Test String', 'My Custom Message');
+			System.assert(false, 'Expected exception');
+		}
+		catch (fflib_ApexMocks.ApexMocksException e)
+		{
+			System.assertEquals('fflib_System.assertEquals expects you to register exactly 1 fflib_IMatcher (typically through the helpers in fflib_Match).', e.getMessage());
+		}
+	}
+
+	@IsTest
+	private static void assertEquals_WithCustomMessage_WithTooManyMatchers_ShouldThrowException()
+	{
+		//Register matchers prematurely
+		fflib_Match.stringStartsWith('Test S');
+		fflib_Match.stringEndsWith('t String');
+		fflib_Match.stringIsNotBlank();
+
+		try
+		{
+			fflib_System.assertEquals(fflib_Match.stringStartsWith('Test S'), 'Test String', 'My Custom Message');
+			System.assert(false, 'Expected exception');
+		}
+		catch (fflib_ApexMocks.ApexMocksException e)
+		{
+			System.assertEquals('fflib_System.assertEquals expects you to register exactly 1 fflib_IMatcher (typically through the helpers in fflib_Match).', e.getMessage());
+		}
+	}
+
+	@IsTest
+	private static void assertEquals_WithCustomMessage_WithMismatch_ShouldThrowException()
+	{
+		try
+		{
+			fflib_System.assertEquals(fflib_Match.stringStartsWith('Test X'), 'Test String', 'My Custom Message');
+			System.assert(false, 'Expected exception');
+		}
+		catch (fflib_ApexMocks.ApexMocksException e)
+		{
+			String expected = 'Actual: Test String -- My Custom Message';
+			String actual = e.getMessage();
+			System.assert(actual.contains(expected), 'Expected: ' + expected + ', Actual: ' + actual);
+		}
+	}
+
+	@IsTest
+	private static void assertEquals_WithCustomMessage_WithMatch_ShouldPass()
+	{
+		fflib_System.assertEquals(fflib_Match.stringStartsWith('Test S'), 'Test String', 'My Custom Message');
+	}
+
+	@IsTest
+	private static void assertEquals_WithCustomMessage_WithCombinedMatcher_ShouldPass()
+	{
+		fflib_System.assertEquals(fflib_Match.allOf(
+				fflib_Match.stringStartsWith('Test S'),
+				fflib_Match.stringEndsWith('t String'),
+				fflib_Match.stringIsNotBlank())
+			, 'Test String', 'My Custom Message');
+	}
+}

--- a/src/classes/fflib_SystemTest.cls-meta.xml
+++ b/src/classes/fflib_SystemTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
In response to https://twitter.com/edmondo1984/status/861562012085694464.

Counterpart for `System.assertEquals(expected, actual)`, but equality is determined through matchers.