### PR TITLE
Feature/instance specificity

### DIFF
--- a/src/classes/fflib_ApexMocks.cls
+++ b/src/classes/fflib_ApexMocks.cls
@@ -235,7 +235,7 @@ public with sharing class fflib_ApexMocks implements System.StubProvider
 	 */
 	public Object mockNonVoidMethod(Object mockInstance, String methodName, List<Type> methodArgTypes, List<Object> methodArgValues)
 	{
-		fflib_QualifiedMethod qm = new fflib_QualifiedMethod(extractTypeName(mockInstance), methodName, methodArgTypes);
+		fflib_QualifiedMethod qm = new fflib_QualifiedMethod(extractTypeName(mockInstance), methodName, methodArgTypes, mockInstance);
 		fflib_MethodArgValues argValues = new fflib_MethodArgValues(methodArgValues);
 
 		fflib_InvocationOnMock invocation = new fflib_InvocationOnMock(qm, argValues, mockInstance);

--- a/src/classes/fflib_ApexMocksConfig.cls
+++ b/src/classes/fflib_ApexMocksConfig.cls
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2017 FinancialForce.com, inc.  All rights reserved.
+ */
+@IsTest
+public class fflib_ApexMocksConfig
+{
+	/**
+	 * When false, stubbed behaviour and invocation counts are shared among all test spies.
+	 * - See fflib_ApexMocksTest.thatMultipleInstancesCanBeMockedDependently
+	 * - This is the default for backwards compatibility.
+	 * When true, each test spy instance has its own stubbed behaviour and invocations.
+	 * - See fflib_ApexMocksTest.thatMultipleInstancesCanBeMockedIndependently
+	 */
+	public static Boolean HasIndependentMocks {get; set;}
+
+	static
+	{
+		HasIndependentMocks = false;
+	}
+}

--- a/src/classes/fflib_ApexMocksConfig.cls-meta.xml
+++ b/src/classes/fflib_ApexMocksConfig.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/fflib_ApexMocksTest.cls
+++ b/src/classes/fflib_ApexMocksTest.cls
@@ -745,6 +745,54 @@ private class fflib_ApexMocksTest
 		System.assertEquals('>Two', mockList.get(3));
 	}
 
+	@isTest
+	static void thatMultipleInstancesCanBeMockedIndependently()
+	{
+		fflib_ApexMocksConfig.HasIndependentMocks = true;
+
+		// Given
+		fflib_ApexMocks mocks = new fflib_ApexMocks();
+		fflib_MyList first = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList second = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		
+		mocks.startStubbing();
+		mocks.when(first.get(0)).thenReturn('First');
+		mocks.when(second.get(0)).thenReturn('Second');
+		mocks.stopStubbing();
+
+		// When
+		String actual = first.get(0);
+
+		// Then
+		System.assertEquals('First', actual, 'Should have returned stubbed value');
+		((fflib_MyList)mocks.verify(first)).get(0);
+		((fflib_MyList)mocks.verify(second, mocks.never())).get(0);
+	}
+
+	@isTest
+	static void thatMultipleInstancesCanBeMockedDependently()
+	{
+		fflib_ApexMocksConfig.HasIndependentMocks = false;
+
+		// Given
+		fflib_ApexMocks mocks = new fflib_ApexMocks();
+		fflib_MyList first = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		fflib_MyList second = (fflib_MyList)mocks.mock(fflib_MyList.class);
+		
+		mocks.startStubbing();
+		mocks.when(first.get(0)).thenReturn('First');
+		mocks.when(second.get(0)).thenReturn('Second');
+		mocks.stopStubbing();
+
+		// When
+		String actual = first.get(0);
+
+		// Then
+		System.assertEquals('Second', actual, 'Should have returned stubbed value');
+		((fflib_MyList)mocks.verify(first)).get(0);
+		((fflib_MyList)mocks.verify(second)).get(0);
+	}
+
 	private class MyException extends Exception
 	{
 	}

--- a/src/classes/fflib_QualifiedMethod.cls
+++ b/src/classes/fflib_QualifiedMethod.cls
@@ -1,36 +1,21 @@
-/**
- * Copyright (c) 2014, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/*
+ * Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
  */
 public with sharing class fflib_QualifiedMethod
 {
+	private Object mockInstance;
 	private String typeName;
 	private String methodName;
 	private List<Type> methodArgTypes;
 	
 	public fflib_QualifiedMethod(String typeName, String methodName, List<Type> methodArgTypes)
 	{
+		this(typeName, methodName, methodArgTypes, null);
+	}
+
+	public fflib_QualifiedMethod(String typeName, String methodName, List<Type> methodArgTypes, Object mockInstance)
+	{
+		this.mockInstance = mockInstance;
 		this.typeName = typeName;
 		this.methodName = methodName;
 		this.methodArgTypes = methodArgTypes;	
@@ -51,6 +36,7 @@ public with sharing class fflib_QualifiedMethod
 		fflib_QualifiedMethod that = other instanceof fflib_QualifiedMethod ? (fflib_QualifiedMethod)other : null;
 		
 		return that != null
+			&& (this.mockInstance === that.mockInstance || !fflib_ApexMocksConfig.HasIndependentMocks)
 			&& this.typeName == that.typeName
 			&& this.methodName == that.methodName
 			&& this.methodArgTypes == that.methodArgTypes;
@@ -65,6 +51,10 @@ public with sharing class fflib_QualifiedMethod
 		Integer prime = 31;
 		Integer result = 1;
 		
+		if (fflib_ApexMocksConfig.HasIndependentMocks)
+		{
+			result = prime * result + ((mockInstance == null) ? 0 : mockInstance.hashCode());
+		}
 		result = prime * result + ((methodArgTypes == null) ? 0 : methodArgTypes.hashCode());
 		result = prime * result + ((methodName == null) ? 0 : methodName.hashCode());
 		result = prime * result + ((typeName == null) ? 0 : typeName.hashCode());

--- a/src/classes/fflib_QualifiedMethodTest.cls
+++ b/src/classes/fflib_QualifiedMethodTest.cls
@@ -1,27 +1,5 @@
-/**
- * Copyright (c) 2014, FinancialForce.com, inc
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *
- * - Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
- *      may be used to endorse or promote products derived from this software without
- *      specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
- * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
- * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/*
+ * Copyright (c) 2016-2017 FinancialForce.com, inc.  All rights reserved.
  */
 @isTest
 public with sharing class fflib_QualifiedMethodTest
@@ -110,5 +88,65 @@ public with sharing class fflib_QualifiedMethodTest
 	public static void toStringReturnsExpectedResult()
 	{
 		System.assertEquals('MyClass.MyMethod(Integer)', new fflib_QualifiedMethod('MyClass', 'MyMethod', new List<Type>{ Integer.class }).toString());
+	}
+
+	@isTest
+	private static void equalsReturnsExpectedResultsForHasDependentMocks()
+	{
+		//Given
+		String instance = 'My object instance';
+		String instance2 = 'My other object instance';
+		fflib_QualifiedMethod qm1 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class } );
+		fflib_QualifiedMethod qm2 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class }, instance);
+		fflib_QualifiedMethod qm3 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class }, instance);
+		fflib_QualifiedMethod qm4 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class }, instance2);
+
+		//When/thens
+		fflib_ApexMocksConfig.HasIndependentMocks = false;
+		
+		System.assertEquals(qm1, qm2);
+		System.assertEquals(qm1, qm3);
+		System.assertEquals(qm1, qm4);
+
+		fflib_ApexMocksConfig.HasIndependentMocks = true;
+
+		System.assertNotEquals(qm1, qm2);
+		System.assertNotEquals(qm1, qm3);
+		System.assertNotEquals(qm1, qm4);
+
+		System.assertEquals(qm2, qm3);
+		System.assertNotEquals(qm2, qm4);
+
+		System.assertNotEquals(qm3, qm4);
+	}
+
+	@isTest
+	private static void hashCodeReturnsExpectedResultsForHasDependentMocks()
+	{
+		//Given
+		String instance = 'My object instance';
+		String instance2 = 'My other object instance';
+		fflib_QualifiedMethod qm1 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class } );
+		fflib_QualifiedMethod qm2 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class }, instance);
+		fflib_QualifiedMethod qm3 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class }, instance);
+		fflib_QualifiedMethod qm4 = new fflib_QualifiedMethod('Type1', 'Method1', new List<Type>{ Integer.class }, instance2);
+
+		//When/thens
+		fflib_ApexMocksConfig.HasIndependentMocks = false;
+		
+		System.assertEquals(qm1.hashCode(), qm2.hashCode());
+		System.assertEquals(qm1.hashCode(), qm3.hashCode());
+		System.assertEquals(qm1.hashCode(), qm4.hashCode());
+
+		fflib_ApexMocksConfig.HasIndependentMocks = true;
+
+		System.assertNotEquals(qm1.hashCode(), qm2.hashCode());
+		System.assertNotEquals(qm1.hashCode(), qm3.hashCode());
+		System.assertNotEquals(qm1.hashCode(), qm4.hashCode());
+
+		System.assertEquals(qm2.hashCode(), qm3.hashCode());
+		System.assertNotEquals(qm2.hashCode(), qm4.hashCode());
+
+		System.assertNotEquals(qm3.hashCode(), qm4.hashCode());
 	}
 }


### PR DESCRIPTION
Makes method invocations instance specific. Now, I can invoke a method on one instance of a mocked object without it counting as an invocation on any other instance.

Added a config class to control the behaviour, to avoid breaking change.