### PR TITLE
Captor doesn't store multiple argument values

### DIFF
--- a/src/classes/fflib_AnyOrder.cls
+++ b/src/classes/fflib_AnyOrder.cls
@@ -50,29 +50,43 @@ public class fflib_AnyOrder extends fflib_MethodVerifier
 	{
 		List<fflib_IMatcher> matchers = fflib_Match.Matching ? fflib_Match.getAndClearMatchers(methodArg.argValues.size()) : null;
 		Integer retval = 0;
-		Map<fflib_MethodArgValues, Integer> methodCountByArgs =
-			fflib_MethodCountRecorder.getMethodCountsByTypeName().get(qm);
-		if (methodCountByArgs != null)
+
+		List<fflib_MethodArgValues> methodArgs =
+			fflib_MethodCountRecorder.getMethodArgumentsByTypeName().get(qm);
+
+		if (methodArgs != null)
 		{
 			if (matchers != null)
 			{
-				for (fflib_MethodArgValues args : methodCountByArgs.keySet())
+				for (fflib_MethodArgValues args : methodArgs)
 				{
 					if (fflib_Match.matchesAllArgs(args, matchers))
 					{
 						capture(matchers);
 
-						retval += methodCountByArgs.get(args);
+						retval ++;
 					}
 				}
 			}
-			else if (methodCountByArgs.get(methodArg) != null)
+			else
 			{
-				return methodCountByArgs.get(methodArg);
+				return countCalls(methodArgs, methodArg);
 			}
 		}
 
 		return retval;
+	}
+
+	private Integer countCalls(List<fflib_MethodArgValues> methodArgs, fflib_MethodArgValues methodArg)
+	{
+		Integer count = 0;
+
+		for(fflib_MethodArgValues arg: methodArgs)
+		{
+			if( arg == methodArg) count++;
+		}
+
+		return count;
 	}
 
 	/*

--- a/src/classes/fflib_ArgumentCaptorTest.cls
+++ b/src/classes/fflib_ArgumentCaptorTest.cls
@@ -661,6 +661,38 @@ private class fflib_ArgumentCaptorTest
 			'nothing should have been capture because the matcher it not really a capture type, but a allOf()');
 	}
 
+	@isTest
+	static void thatCaptureAllArgumentswhenMethodIsCalledWithTheSameArgument()
+	{
+		// Given
+		fflib_ApexMocks mocks = new fflib_ApexMocks();
+		fflib_MyList mockList = (fflib_MyList)mocks.mock(fflib_MyList.class);
+
+		// When
+		mockList.add('Fred');
+		mockList.add('Barney');
+		mockList.add('Wilma');
+		mockList.add('Barney');
+		mockList.add('Barney');
+		mockList.add('Betty');
+
+		// Then
+		fflib_ArgumentCaptor argument = fflib_ArgumentCaptor.forClass(String.class);
+
+		((fflib_MyList.IList) mocks.verify(mockList, 6)).add((String) argument.capture());
+
+		List<object> argsCaptured = argument.getAllValues();
+
+		System.assertEquals(6, argsCaptured.size(), 'expected 6 arguments to be captured');
+
+		System.assertEquals('Fred', (String) argsCaptured[0], 'the first value is not as expected');
+		System.assertEquals('Barney', (String) argsCaptured[1], 'the second value is not as expected');
+		System.assertEquals('Wilma', (String) argsCaptured[2], 'the third value is not as expected');
+		System.assertEquals('Barney', (String) argsCaptured[3], 'the fourth value is not as expected');
+		System.assertEquals('Barney', (String) argsCaptured[4], 'the fifth value is not as expected');
+		System.assertEquals('Betty', (String) argsCaptured[5], 'the sixth value is not as expected');
+	}
+
 
 	private class TestInnerClass
 	{

--- a/src/classes/fflib_MethodCountRecorder.cls
+++ b/src/classes/fflib_MethodCountRecorder.cls
@@ -8,16 +8,15 @@
 public with sharing class fflib_MethodCountRecorder
 {
 	/*
-	 * Map of method counts by type name.
+	 * Map of method arguments by type name.
 	 *
 	 * Key: qualifiedMethod
-	 * Object: map of method calls by method.
+	 * Object: list of method arguments.
 	 *
-	 * Key: methodArgValues
 	 * Object: map of count by method call argument.
 	 */
-	private static Map<fflib_QualifiedMethod, Map<fflib_MethodArgValues, Integer>> methodCountsByTypeName =
-		new Map<fflib_QualifiedMethod, Map<fflib_MethodArgValues, Integer>>();
+	private static Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> methodArgumentsByTypeName =
+		new Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>>();
 
 	private static List<fflib_InvocationOnMock> orderedMethodCalls =
 		new List<fflib_InvocationOnMock>();
@@ -35,9 +34,9 @@ public with sharing class fflib_MethodCountRecorder
 	 * Getter for the map of the method's calls with the related arguments.
 	 * @return The map of methods called with the arguments.
 	 */
-	public static Map<fflib_QualifiedMethod, Map<fflib_MethodArgValues, Integer>> getMethodCountsByTypeName()
+	public static Map<fflib_QualifiedMethod, List<fflib_MethodArgValues>> getMethodArgumentsByTypeName()
 	{
-		return methodCountsByTypeName;
+		return methodArgumentsByTypeName;
 	}
 
 	/**
@@ -46,19 +45,16 @@ public with sharing class fflib_MethodCountRecorder
 	 */
 	public void recordMethod(fflib_InvocationOnMock invocation)
 	{
-		Map<fflib_MethodArgValues, Integer> methodCountByArgs =
-			methodCountsByTypeName.get(invocation.getMethod());
+		List<fflib_MethodArgValues> methodArgs =
+			methodArgumentsByTypeName.get(invocation.getMethod());
 
-		if (methodCountByArgs == null)
+		if (methodArgs == null)
 		{
-			methodCountByArgs = new Map<fflib_MethodArgValues, Integer>();
-			methodCountsByTypeName.put(invocation.getMethod(), methodCountByArgs);
+			methodArgs = new List<fflib_MethodArgValues>();
+			methodArgumentsByTypeName.put(invocation.getMethod(), methodArgs);
 		}
 
-		Integer currentCount = methodCountByArgs.get(invocation.getMethodArgValues());
-		Integer newCount = currentCount == null ? 1 : ++currentCount;
-
-		methodCountByArgs.put(invocation.getMethodArgValues(), newCount);
+		methodArgs.add(invocation.getMethodArgValues());
 
 		orderedMethodCalls.add(invocation);
 	}


### PR DESCRIPTION
fixed bug: when a method was called multiple times with the same argument value it was storing only one value instead of each time. Aligned the code to the internal repository where the bug has been already fixed