### PR TITLE
Add more setup steps to README and fix markdown rendering issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .settings/com.salesforce.ide.core.prefs
 
 salesforce.schema
+
+build.properties

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#FinancialForce ApexMocks Framework
+# FinancialForce ApexMocks Framework
 
 [![Build Status](https://travis-ci.org/financialforcedev/fflib-apex-mocks.svg)](https://travis-ci.org/financialforcedev/fflib-apex-mocks)
 
@@ -11,7 +11,12 @@ It derives it's inspiration from the well known Java mocking framework [Mockito]
        src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/src/main/webapp/resources/img/deploy.png">
 </a>
 
-##Using ApexMocks on Force.com
+## Setup
+- Clone this repo
+- Copy the build.properties.template file into build.properties file and add your salesforce username and password.
+- Do `ant deploy` to get the classes in your dev org.
+
+## Using ApexMocks on Force.com
 
 ApexMocks allows you to write tests to both verify behaviour and stub dependencies.
 
@@ -57,7 +62,7 @@ Lets assume we've written our own list interface fflib_MyList.IList that we want
 		mocks.when(mockList.get(1)).thenReturn('fred');
 		mocks.stopStubbing();
 
-##Stub API
+## Stub API
 ApexMocks now implements the [Stub API](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_testing_stub_api.htm)!
 
 Previously, stub objects had to be generated using the ApexMocks generator at compile time.
@@ -68,7 +73,7 @@ Now, stub objects can be generated dynamically at run time.
 
 You can continue to use the ApexMocks generator, if you wish, but this is no longer a prerequisite to using ApexMocks.
 
-##Generating Mock files
+## Generating Mock files
 
 Run the apex mocks generator from the command line.
 
@@ -88,7 +93,7 @@ Instantiate the generated classes as follows:
 		fflib_ApexMocks mocks = new fflib_ApexMocks();
 		fflib_MyList.IList mockList = new MockMyList(mocks);
 
-##Documentation
+## Documentation
 
 * [ApexMocks Framework Tutorial](http://code4cloud.wordpress.com/2014/05/06/apexmocks-framework-tutorial/)
 * [Simple Dependency Injection](http://code4cloud.wordpress.com/2014/05/09/simple-dependency-injection/)

--- a/build.properties.template
+++ b/build.properties.template
@@ -1,0 +1,5 @@
+# Specify the login credentials for the desired Salesforce organization
+sf.username=<salesforce username>
+sf.password=<salesforce password>
+sf.server = https://login.salesforce.com
+sf.maxPoll = 20

--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,7 @@
 <project xmlns:sf="antlib:com.salesforce" basedir="."  default="deploy">
 	
-	<property name="sf.server" value="https://login.salesforce.com"/>
+	<property file="build.properties"/>
+
 	<import file="${basedir}/lib/exec_anon.xml"/> 
 	<import file="${basedir}/lib/undeploy.xml"/>
 
@@ -11,12 +12,12 @@
 		classpath="${basedir}/lib/ant-salesforce.jar"/>
 	
 	<!-- Deploy -->
-	<target name="deploy" depends="undeploy">
+	<target name="deploy">
 		<sf:deploy 
 	        username="${sf.username}" 
 	        password="${sf.password}" 
 	        serverurl="${sf.server}"
-	        testLevel="RunLocalTests" 
+	        testLevel="NoTestRun" 
 	        deployRoot="${basedir}/src"/>
 	</target>
 		


### PR DESCRIPTION
Hi Maintainers,

I'm Yi from Kooltra, a Canadian based Salesforce ISV for currency exchange broker/dealer back-offices. As we're starting to investigate more rigorous testing, we found ApexMocks super useful. As we started experimenting with it, I would like to just add a couple steps in the README section to help developers get the ApexMocks classes into their developer orgs for experimentation. Hope that's useful for you to merge back as well.

I would also like to take the opportunity to ask a question about the best way to use the ApexMocks library in the Salesforce packaging process. As an ISV, we sell Salesforce managed packages. During package upload, we'd like the tests to be run with ApexMocks' help. Is there a best way to do that? Or if you know any other places where I have a better chance of getting an answer?

Much appreciated!