### PR TITLE
Add Matcher sObjectsWith

### DIFF
--- a/src/classes/fflib_Match.cls
+++ b/src/classes/fflib_Match.cls
@@ -1059,7 +1059,7 @@ public class fflib_Match
 	{
 		return (SObject)matches(new fflib_MatcherDefinitions.SObjectWith(toMatch));
 	}
-    /**
+	/**
 	 * Registers a matcher which will check if the method is called with a list of SObject
 	 * @param toMatch A list of Map of SObjectFields to required values, to be compared to concrete SObject records
 	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
@@ -1069,7 +1069,7 @@ public class fflib_Match
 		return (SObject[])matches(new fflib_MatcherDefinitions.SObjectsWith(toMatch,true));
 	}
     
-     /**
+	/**
 	 * Registers a matcher which will check if the method is called with a list of SObject
 	 * @param toMatch A list of Map of SObjectFields to required values, to be compared to concrete SObject records. Comparison can be order dependent
 	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked

--- a/src/classes/fflib_Match.cls
+++ b/src/classes/fflib_Match.cls
@@ -1059,6 +1059,26 @@ public class fflib_Match
 	{
 		return (SObject)matches(new fflib_MatcherDefinitions.SObjectWith(toMatch));
 	}
+    /**
+	 * Registers a matcher which will check if the method is called with a list of SObject
+	 * @param toMatch A list of Map of SObjectFields to required values, to be compared to concrete SObject records
+	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
+	 */
+	public static SObject[] sObjectsWith(list<Map<Schema.SObjectField, Object>> toMatch)
+	{
+		return (SObject[])matches(new fflib_MatcherDefinitions.SObjectsWith(toMatch,true));
+	}
+    
+     /**
+	 * Registers a matcher which will check if the method is called with a list of SObject
+	 * @param toMatch A list of Map of SObjectFields to required values, to be compared to concrete SObject records. Comparison can be order dependent
+	 * @return SObject a dummy object of the correct type, so that when called inline as part of a method call, the correct method is invoked
+	 */
+	public static SObject[] sObjectsWith(list<Map<Schema.SObjectField, Object>> toMatch, Boolean matchInOrder)
+	{
+		return (SObject[])matches(new fflib_MatcherDefinitions.SObjectsWith(toMatch,matchInOrder));
+	}
+    
 	/**
 	 * Registers a matcher which will check if the method is called with an SObject
 	 * @param toMatch The Id to be compared

--- a/src/classes/fflib_MatchTest.cls
+++ b/src/classes/fflib_MatchTest.cls
@@ -1217,6 +1217,54 @@ public with sharing class fflib_MatchTest
 		System.assert(registeredMatchers[0] instanceof fflib_MatcherDefinitions.SObjectWith);
 	}
 
+    @isTest
+	private static void sObjectsWithRegistersCorrectMatcherType()
+	{
+		//Given
+		Schema.SObjectType ot = Schema.getGlobalDescribe().get('Account');
+		if (ot == null)
+		{
+			return;
+		}
+
+		Schema.SObjectField f = ot.getDescribe().fields.getMap().get('Id');
+
+		//When
+		SObject[] x = fflib_Match.sObjectsWith(new list<Map<Schema.SObjectField, Object>>{ 
+            new map<Schema.SObjectField,Object> {f=>null}
+        	});
+
+		//Then
+		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
+		System.assertNotEquals(null, registeredMatchers);
+		System.assertEquals(1, registeredMatchers.size());
+		System.assert(registeredMatchers[0] instanceof fflib_MatcherDefinitions.SObjectsWith);
+	}
+
+    @isTest
+	private static void sObjectsWithMatchInOrderRegistersCorrectMatcherType()
+	{
+		//Given
+		Schema.SObjectType ot = Schema.getGlobalDescribe().get('Account');
+		if (ot == null)
+		{
+			return;
+		}
+
+		Schema.SObjectField f = ot.getDescribe().fields.getMap().get('Id');
+
+		//When
+		SObject[] x = fflib_Match.sObjectsWith(new list<Map<Schema.SObjectField, Object>>{ 
+            new map<Schema.SObjectField,Object> {f=>null}
+        	}, false);
+
+		//Then
+		List<fflib_IMatcher> registeredMatchers = fflib_Match.getAndClearMatchers(1);
+		System.assertNotEquals(null, registeredMatchers);
+		System.assertEquals(1, registeredMatchers.size());
+		System.assert(registeredMatchers[0] instanceof fflib_MatcherDefinitions.SObjectsWith,registeredMatchers);
+	}
+    
 	@isTest
 	private static void sObjectWithIdRegistersCorrectMatcherType()
 	{

--- a/src/classes/fflib_MatcherDefinitions.cls
+++ b/src/classes/fflib_MatcherDefinitions.cls
@@ -864,7 +864,7 @@ public with sharing class fflib_MatcherDefinitions
 						}      
 					}
 					return true;    
-                }    
+				}    
 			}
 			return false;
 		}

--- a/src/classes/fflib_MatcherDefinitions.cls
+++ b/src/classes/fflib_MatcherDefinitions.cls
@@ -834,7 +834,8 @@ public with sharing class fflib_MatcherDefinitions
 					}
 				}
 				else
-                {	// match in any order (but every arg must be matched only once)
+                {	
+                	// match in any order (but every arg must be matched only once)
 					for (Integer i = 0; i < sobjsArg.size(); i++) 
                     {
                         argMatchedCounts.add(0);

--- a/src/classes/fflib_MatcherDefinitions.cls
+++ b/src/classes/fflib_MatcherDefinitions.cls
@@ -726,28 +726,11 @@ public with sharing class fflib_MatcherDefinitions
 			if (arg != null && arg instanceof SObject)
 			{
 				SObject soArg = (SObject)arg;
-				for (Schema.SObjectField f : toMatch.keySet())
-				{
-					Object valueToMatch = toMatch.get(f);
-
-					try
-					{
-						if (soArg.get(f) != valueToMatch)
-						{
-							return false;
-						}
-					}
-					catch (Exception e)
-					{
-						//If we fail to get the value for a field it's either:
-						// - 'SObject row was retrieved via SOQL without querying the requested field' as a mismatch
-						// - System.SObjectException - Account.Id does not belong to SObject type Opportunity
-						//Don't care too much, just treat this as a mismatch.
-						return false;
-					}
-				}
-
-				return true;
+				if (!sobjectMatches(soArg,this.toMatch))
+                {
+                    return false;
+                }
+                return true;
 			}
 
 			return false;
@@ -764,6 +747,171 @@ public with sharing class fflib_MatcherDefinitions
 		}
 	}
 
+	/**
+	 * SObjectsWith matcher: compares the supplied list<Sobject> argument against a list<Map<Schema.SObjectField, Object>>, representing fields and their expected values.
+	 * Each list element represents one Sobject in a list supplied to a mocked method that accepts list<SObject>. 
+	 * Each list element that is a map<Schema.SobjectField,Object> is compared against the equivalent argument list element position
+	 * 
+	 * Example:
+	 *   You use uow.registerNew(someListofAccounts). You mock uow in the testmethod.
+     *   toMatch is new list<Schema.SObjectField,Object> {
+     *      new map<Schema.SobjectField,Object> {Account.Name => 'foo'},
+     *      new map<Schema.SobjectField,Object> {Account.Name => 'bar'}
+     *    } 
+     *   By default, matchers compare against argument elements in order, viz:
+     * 		The matcher will compare the first Account in the list passed to uow.registerNew to the first map of field values (i.e. Account[0].Name must be 'foo')
+     *   	The matcher then compares the second Account in the list passed to uow.registerNew to the second map of field values (i.e. Account[1].Name must be 'bar')
+     * 	
+     *   Optional second argument matchInOrderr if false means that each argument element is compared against all matcher elements
+     *   if everuy argument is matched exactly once and no matcher matches more than once, then the match is true
+     * 
+     * If the arity of the list passed in the mocked method doesn't agree with the arity of the map of expected field values, false is returned
+     * 
+	 * Note. this method silently catches exceptions getting values for the supplied fields from the arguments supplied in method calls.
+	 * 
+	 * If your matcher is mysteriously failing for your SObject record, it may be getting silent 'SObject row was retrieved via SOQL without querying
+	 * the requested field' exceptions, because you haven't queried all of the fields used in this matcher.
+	 */
+	public class SObjectsWith implements fflib_IMatcher
+	{
+		private list<Map<Schema.SObjectField, Object>> toMatch;
+        private Boolean matchInOrder {
+            get 
+            {
+                return matchInOrder == null ? false : matchInOrder;
+            }
+            set;
+        }
+
+		/**
+		 * SObjectsWith constructor
+		 * @param toMatch A list of maps of fields to their values to be compared. We compare each of these fields against the supplied list of sobject's field values.
+		 * @return fflib_MatcherDefinitions.SObjectWith A new SObjectWith instance
+		 */
+		public SObjectsWith(list<Map<Schema.SObjectField, Object>> toMatch, Boolean matchInOrder)
+		{
+			this.toMatch = validate(toMatch);
+            this.matchInOrder = matchInOrder;
+		}
+		public SObjectsWith(list<Map<Schema.SObjectField, Object>> toMatch)
+		{
+			this.toMatch = validate(toMatch);
+            this.matchInOrder = true;
+		}
+		public Boolean matches(Object arg)
+		{
+			if (arg != null && arg instanceof list<SObject>)
+			{
+				SObject[] sobjsArg = (SObject[])arg;
+                list<map<Schema.SObjectField,Object>> toMatches = new list<map<Schema.SObjectField,Object>>();
+                
+                //	Counters for matchInOrder = false; not relevant for matchInOrder = true
+                list<Integer> argMatchedCounts = new list<Integer>();		// # times matched by a matcher. anything other than 1 is match error
+                list<Integer> matcherMatchedCounts = new list<Integer>(); 	// for each map<Schema.SObjectField,Object>
+        																	// # args that match it. Anything other than 1 is match error
+                
+                
+                for (map<Schema.SObjectField,Object> mtchElm : toMatch)
+                {
+                    toMatches.add(mtchElm);
+                    matcherMatchedCounts.add(0);
+                }   
+                
+                if (sobjsArg.size() != toMatches.size())	// arity of arguments to mocked method doesn't agree with arity of expected matches
+                {
+                    return false;
+                }
+                
+                if (matchInOrder)
+                {
+                    for (Integer i = 0; i < sobjsArg.size(); i++) 
+                    {	// match in order (toMatch[i] must match arg[i])
+                        if (!sobjectMatches(sobjsArg[i],toMatches[i]))
+                        {
+                            return false;
+                        }
+                        return true;
+                    }
+                }
+                else
+                {	// match in any order (but every arg must be matched only once)
+                    for (Integer i = 0; i < sobjsArg.size(); i++) 
+                    {
+                        argMatchedCounts.add(0);
+                        // For each arg passed to mocked method, see if any match in the list of match field maps. 
+                        // Loop within loop so not hugely efficient but there are no IDs to rely on.
+                        // Avoid unit test methods that build huge lists of expected results
+                         
+                        for (Integer m = 0; m < toMatches.size(); m++)
+                        {
+                            if (sobjectMatches(sobjsArg[i],toMatches[m]))
+                            {
+                                argMatchedCounts[i] ++;
+                                matcherMatchedCounts[m] ++;
+                            }
+                        }
+                    }
+                    // Check to see that every arg was matched only once
+                    // Check to see that every matcher matched only once
+                    // Anything else is a match fail
+                    
+                    for (Integer i=0; i < argMatchedCounts.size(); i++)
+                    {
+                        if (argMatchedCounts[i] != 1 || matcherMatchedCounts[i] != 1) 
+                        {
+                            return false;
+                        }      
+                    }
+                    return true;
+                    
+                }    
+                	
+            }
+			return false;
+		}
+
+		private list<Map<Schema.SObjectField, Object>> validate(list<Map<Schema.SObjectField, Object>> arg)
+		{
+			if (arg == null || arg.isEmpty() )
+			{
+				throw new fflib_ApexMocks.ApexMocksException('Arg cannot be null/empty/other than list of map<Schema.SobjectField,Object>: ' + arg);
+			}
+
+			return arg;
+		}
+        
+
+	}    
+  
+    /**
+     * helper for the sObjectWith, sObjectsWith matchers
+     * Compares to see if the field values in toMatch exist in the sobj
+    **/
+    private static Boolean sObjectMatches(Sobject sobj, map<Schema.SobjectField,Object> toMatch)
+    {
+        for (Schema.SObjectField f : toMatch.keySet())
+        {
+            Object valueToMatch = toMatch.get(f);
+            
+            try
+            {
+                if (sobj.get(f) != valueToMatch)
+                {
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                //If we fail to get the value for a field it's either:
+                // - 'SObject row was retrieved via SOQL without querying the requested field' as a mismatch
+                // - System.SObjectException - Account.Id does not belong to SObject type Opportunity
+                //Don't care too much, just treat this as a mismatch.
+                return false;
+            }
+        }
+		return true;  // map of expected fieldvals found in sobj arg
+    }
+    
 	/**
 	 * SObjectWithId matcher: checks if the supplied argument has the specified Id
 	 */

--- a/src/classes/fflib_MatcherDefinitions.cls
+++ b/src/classes/fflib_MatcherDefinitions.cls
@@ -834,40 +834,38 @@ public with sharing class fflib_MatcherDefinitions
 					}
 				}
 				else
-                {	
-			// match in any order (but every arg must be matched only once)
-			for (Integer i = 0; i < sobjsArg.size(); i++) 
-                    {
-                        argMatchedCounts.add(0);
-                        // For each arg passed to mocked method, see if any match in the list of match field maps. 
-                        // Loop within loop so not hugely efficient but there are no IDs to rely on.
-                        // Avoid unit test methods that build huge lists of expected results
+				{	
+					// match in any order (but every arg must be matched only once)
+					for (Integer i = 0; i < sobjsArg.size(); i++) 
+					{
+						argMatchedCounts.add(0);
+						// For each arg passed to mocked method, see if any match in the list of match field maps. 
+						// Loop within loop so not hugely efficient but there are no IDs to rely on.
+						// Avoid unit test methods that build huge lists of expected results
                          
-                        for (Integer m = 0; m < toMatches.size(); m++)
-                        {
-                            if (sobjectMatches(sobjsArg[i],toMatches[m]))
-                            {
-                                argMatchedCounts[i] ++;
-                                matcherMatchedCounts[m] ++;
-                            }
-                        }
-                    }
-                    // Check to see that every arg was matched only once
-                    // Check to see that every matcher matched only once
-                    // Anything else is a match fail
+						for (Integer m = 0; m < toMatches.size(); m++)
+						{
+							if (sobjectMatches(sobjsArg[i],toMatches[m]))
+							{
+								argMatchedCounts[i] ++;
+								matcherMatchedCounts[m] ++;
+							}
+						}
+					}
+					// Check to see that every arg was matched only once
+					// Check to see that every matcher matched only once
+					// Anything else is a match fail
                     
-                    for (Integer i=0; i < argMatchedCounts.size(); i++)
-                    {
-                        if (argMatchedCounts[i] != 1 || matcherMatchedCounts[i] != 1) 
-                        {
-                            return false;
-                        }      
-                    }
-                    return true;
-                    
+					for (Integer i=0; i < argMatchedCounts.size(); i++)
+					{
+						if (argMatchedCounts[i] != 1 || matcherMatchedCounts[i] != 1) 
+						{
+							return false;
+						}      
+					}
+					return true;    
                 }    
-                	
-            }
+			}
 			return false;
 		}
 

--- a/src/classes/fflib_MatcherDefinitions.cls
+++ b/src/classes/fflib_MatcherDefinitions.cls
@@ -825,17 +825,17 @@ public with sharing class fflib_MatcherDefinitions
 				if (matchInOrder)
 				{
 					for (Integer i = 0; i < sobjsArg.size(); i++) 
-                    {	// match in order (toMatch[i] must match arg[i])
-                        if (!sobjectMatches(sobjsArg[i],toMatches[i]))
-                        {
-                            return false;
-                        }
-                        return true;
-                    }
+					{	// match in order (toMatch[i] must match arg[i])
+						if (!sobjectMatches(sobjsArg[i],toMatches[i]))
+						{
+							return false;
+						}
+						return true;
+					}
                 }
                 else
                 {	// match in any order (but every arg must be matched only once)
-                    for (Integer i = 0; i < sobjsArg.size(); i++) 
+					for (Integer i = 0; i < sobjsArg.size(); i++) 
                     {
                         argMatchedCounts.add(0);
                         // For each arg passed to mocked method, see if any match in the list of match field maps. 

--- a/src/classes/fflib_MatcherDefinitions.cls
+++ b/src/classes/fflib_MatcherDefinitions.cls
@@ -748,40 +748,40 @@ public with sharing class fflib_MatcherDefinitions
 	}
 
 	/**
-	 * SObjectsWith matcher: compares the supplied list<Sobject> argument against a list<Map<Schema.SObjectField, Object>>, representing fields and their expected values.
-	 * Each list element represents one Sobject in a list supplied to a mocked method that accepts list<SObject>. 
-	 * Each list element that is a map<Schema.SobjectField,Object> is compared against the equivalent argument list element position
-	 * 
-	 * Example:
-	 *   You use uow.registerNew(someListofAccounts). You mock uow in the testmethod.
-     *   toMatch is new list<Schema.SObjectField,Object> {
-     *      new map<Schema.SobjectField,Object> {Account.Name => 'foo'},
-     *      new map<Schema.SobjectField,Object> {Account.Name => 'bar'}
-     *    } 
-     *   By default, matchers compare against argument elements in order, viz:
-     * 		The matcher will compare the first Account in the list passed to uow.registerNew to the first map of field values (i.e. Account[0].Name must be 'foo')
-     *   	The matcher then compares the second Account in the list passed to uow.registerNew to the second map of field values (i.e. Account[1].Name must be 'bar')
-     * 	
-     *   Optional second argument matchInOrderr if false means that each argument element is compared against all matcher elements
-     *   if everuy argument is matched exactly once and no matcher matches more than once, then the match is true
-     * 
-     * If the arity of the list passed in the mocked method doesn't agree with the arity of the map of expected field values, false is returned
-     * 
-	 * Note. this method silently catches exceptions getting values for the supplied fields from the arguments supplied in method calls.
-	 * 
-	 * If your matcher is mysteriously failing for your SObject record, it may be getting silent 'SObject row was retrieved via SOQL without querying
-	 * the requested field' exceptions, because you haven't queried all of the fields used in this matcher.
-	 */
+	* SObjectsWith matcher: compares the supplied list<Sobject> argument against a list<Map<Schema.SObjectField, Object>>, representing fields and their expected values.
+	* Each list element represents one Sobject in a list supplied to a mocked method that accepts list<SObject>. 
+	* Each list element that is a map<Schema.SobjectField,Object> is compared against the equivalent argument list element position
+	* 
+	* Example:
+	*   You use uow.registerNew(someListofAccounts). You mock uow in the testmethod.
+	*   toMatch is new list<Schema.SObjectField,Object> {
+	*      new map<Schema.SobjectField,Object> {Account.Name => 'foo'},
+	*      new map<Schema.SobjectField,Object> {Account.Name => 'bar'}
+	*    } 
+	*   By default, matchers compare against argument elements in order, viz:
+	* 		The matcher will compare the first Account in the list passed to uow.registerNew to the first map of field values (i.e. Account[0].Name must be 'foo')
+	*   	The matcher then compares the second Account in the list passed to uow.registerNew to the second map of field values (i.e. Account[1].Name must be 'bar')
+	* 	
+	*   Optional second argument matchInOrderr if false means that each argument element is compared against all matcher elements
+	*   if everuy argument is matched exactly once and no matcher matches more than once, then the match is true
+	* 
+	* If the arity of the list passed in the mocked method doesn't agree with the arity of the map of expected field values, false is returned
+	* 
+	* Note. this method silently catches exceptions getting values for the supplied fields from the arguments supplied in method calls.
+	* 
+	* If your matcher is mysteriously failing for your SObject record, it may be getting silent 'SObject row was retrieved via SOQL without querying
+	* the requested field' exceptions, because you haven't queried all of the fields used in this matcher.
+	*/
 	public class SObjectsWith implements fflib_IMatcher
 	{
 		private list<Map<Schema.SObjectField, Object>> toMatch;
-        private Boolean matchInOrder {
-            get 
-            {
-                return matchInOrder == null ? false : matchInOrder;
-            }
-            set;
-        }
+		private Boolean matchInOrder {
+			get 
+			{
+				return matchInOrder == null ? false : matchInOrder;
+			}
+			set;
+		}
 
 		/**
 		 * SObjectsWith constructor
@@ -791,40 +791,40 @@ public with sharing class fflib_MatcherDefinitions
 		public SObjectsWith(list<Map<Schema.SObjectField, Object>> toMatch, Boolean matchInOrder)
 		{
 			this.toMatch = validate(toMatch);
-            this.matchInOrder = matchInOrder;
+			this.matchInOrder = matchInOrder;
 		}
 		public SObjectsWith(list<Map<Schema.SObjectField, Object>> toMatch)
 		{
 			this.toMatch = validate(toMatch);
-            this.matchInOrder = true;
+			this.matchInOrder = true;
 		}
 		public Boolean matches(Object arg)
 		{
 			if (arg != null && arg instanceof list<SObject>)
 			{
 				SObject[] sobjsArg = (SObject[])arg;
-                list<map<Schema.SObjectField,Object>> toMatches = new list<map<Schema.SObjectField,Object>>();
+				list<map<Schema.SObjectField,Object>> toMatches = new list<map<Schema.SObjectField,Object>>();
                 
-                //	Counters for matchInOrder = false; not relevant for matchInOrder = true
-                list<Integer> argMatchedCounts = new list<Integer>();		// # times matched by a matcher. anything other than 1 is match error
-                list<Integer> matcherMatchedCounts = new list<Integer>(); 	// for each map<Schema.SObjectField,Object>
+				//	Counters for matchInOrder = false; not relevant for matchInOrder = true
+				list<Integer> argMatchedCounts = new list<Integer>();		// # times matched by a matcher. anything other than 1 is match error
+				list<Integer> matcherMatchedCounts = new list<Integer>(); 	// for each map<Schema.SObjectField,Object>
         																	// # args that match it. Anything other than 1 is match error
                 
                 
-                for (map<Schema.SObjectField,Object> mtchElm : toMatch)
-                {
-                    toMatches.add(mtchElm);
-                    matcherMatchedCounts.add(0);
-                }   
+				for (map<Schema.SObjectField,Object> mtchElm : toMatch)
+				{
+					toMatches.add(mtchElm);
+					matcherMatchedCounts.add(0);
+				}   
                 
-                if (sobjsArg.size() != toMatches.size())	// arity of arguments to mocked method doesn't agree with arity of expected matches
-                {
-                    return false;
-                }
+				if (sobjsArg.size() != toMatches.size())	// arity of arguments to mocked method doesn't agree with arity of expected matches
+				{
+					return false;
+				}
                 
-                if (matchInOrder)
-                {
-                    for (Integer i = 0; i < sobjsArg.size(); i++) 
+				if (matchInOrder)
+				{
+					for (Integer i = 0; i < sobjsArg.size(); i++) 
                     {	// match in order (toMatch[i] must match arg[i])
                         if (!sobjectMatches(sobjsArg[i],toMatches[i]))
                         {

--- a/src/classes/fflib_MatcherDefinitions.cls
+++ b/src/classes/fflib_MatcherDefinitions.cls
@@ -832,8 +832,8 @@ public with sharing class fflib_MatcherDefinitions
 						}
 						return true;
 					}
-                }
-                else
+				}
+				else
                 {	// match in any order (but every arg must be matched only once)
 					for (Integer i = 0; i < sobjsArg.size(); i++) 
                     {

--- a/src/classes/fflib_MatcherDefinitions.cls
+++ b/src/classes/fflib_MatcherDefinitions.cls
@@ -836,7 +836,7 @@ public with sharing class fflib_MatcherDefinitions
 				else
                 {	
                 	// match in any order (but every arg must be matched only once)
-					for (Integer i = 0; i < sobjsArg.size(); i++) 
+			for (Integer i = 0; i < sobjsArg.size(); i++) 
                     {
                         argMatchedCounts.add(0);
                         // For each arg passed to mocked method, see if any match in the list of match field maps. 

--- a/src/classes/fflib_MatcherDefinitions.cls
+++ b/src/classes/fflib_MatcherDefinitions.cls
@@ -727,10 +727,10 @@ public with sharing class fflib_MatcherDefinitions
 			{
 				SObject soArg = (SObject)arg;
 				if (!sobjectMatches(soArg,this.toMatch))
-                {
-                    return false;
-                }
-                return true;
+				{
+					return false;
+				}
+				return true;
 			}
 
 			return false;

--- a/src/classes/fflib_MatcherDefinitions.cls
+++ b/src/classes/fflib_MatcherDefinitions.cls
@@ -835,8 +835,8 @@ public with sharing class fflib_MatcherDefinitions
 				}
 				else
                 {	
-                	// match in any order (but every arg must be matched only once)
-			for (Integer i = 0; i < sobjsArg.size(); i++) 
+		// match in any order (but every arg must be matched only once)
+		for (Integer i = 0; i < sobjsArg.size(); i++) 
                     {
                         argMatchedCounts.add(0);
                         // For each arg passed to mocked method, see if any match in the list of match field maps. 

--- a/src/classes/fflib_MatcherDefinitions.cls
+++ b/src/classes/fflib_MatcherDefinitions.cls
@@ -835,8 +835,8 @@ public with sharing class fflib_MatcherDefinitions
 				}
 				else
                 {	
-		// match in any order (but every arg must be matched only once)
-		for (Integer i = 0; i < sobjsArg.size(); i++) 
+			// match in any order (but every arg must be matched only once)
+			for (Integer i = 0; i < sobjsArg.size(); i++) 
                     {
                         argMatchedCounts.add(0);
                         // For each arg passed to mocked method, see if any match in the list of match field maps. 

--- a/src/classes/fflib_MatcherDefinitionsTest.cls
+++ b/src/classes/fflib_MatcherDefinitionsTest.cls
@@ -38,8 +38,8 @@ public class fflib_MatcherDefinitionsTest
 	private static final SObject ACCOUNT_RECORD;
 	private static final Schema.SObjectType ACCOUNT_OBJECT_TYPE;
 	private static final Schema.SObjectType OPPORTUNITY_OBJECT_TYPE;
-    private static final Schema.SobjectType GROUP_OBJECT_TYPE;
-    private static final Sobject[] GROUP_RECORDS;
+	private static final Schema.SobjectType GROUP_OBJECT_TYPE;
+	private static final Sobject[] GROUP_RECORDS;
 	
 	static
 	{

--- a/src/classes/fflib_MatcherDefinitionsTest.cls
+++ b/src/classes/fflib_MatcherDefinitionsTest.cls
@@ -47,7 +47,7 @@ public class fflib_MatcherDefinitionsTest
 
 		ACCOUNT_OBJECT_TYPE = globalDescribe.get('Account');
 		OPPORTUNITY_OBJECT_TYPE = globalDescribe.get('Opportunity');
-        GROUP_OBJECT_TYPE = globalDescribe.get('Group');
+		GROUP_OBJECT_TYPE = globalDescribe.get('Group');
 		
 		SObject accountRecord = ACCOUNT_OBJECT_TYPE.newSObject();
 		accountRecord.put('Name', 'MatcherDefinitionTestAccount' + System.now());

--- a/src/classes/fflib_MatcherDefinitionsTest.cls
+++ b/src/classes/fflib_MatcherDefinitionsTest.cls
@@ -57,11 +57,11 @@ public class fflib_MatcherDefinitionsTest
 
 		ACCOUNT_RECORD = Database.query('SELECT Id, Name FROM Account WHERE Id = :accountId LIMIT 1');
         
-        GROUP_RECORDS = new list<Group> {
-            new Group(Name = 'MatcherDefnTestGroup0'+System.now(), DeveloperName='MatcherDefnTestGroup0'+System.now().getTime(),Type='Queue'),
-            new Group(Name = 'MatcherDefnTestGroup1'+System.now(), DeveloperName='MatcherDefnTestGroup1'+System.now().getTime(),Type='Queue')
-        };
-        insert GROUP_RECORDS;    
+		GROUP_RECORDS = new list<Group> {
+			new Group(Name = 'MatcherDefnTestGroup0'+System.now(), DeveloperName='MatcherDefnTestGroup0'+System.now().getTime(),Type='Queue'),
+			new Group(Name = 'MatcherDefnTestGroup1'+System.now(), DeveloperName='MatcherDefnTestGroup1'+System.now().getTime(),Type='Queue')
+		};
+		insert GROUP_RECORDS;    
         
 	}
 

--- a/src/classes/fflib_MatcherDefinitionsTest.cls
+++ b/src/classes/fflib_MatcherDefinitionsTest.cls
@@ -38,6 +38,8 @@ public class fflib_MatcherDefinitionsTest
 	private static final SObject ACCOUNT_RECORD;
 	private static final Schema.SObjectType ACCOUNT_OBJECT_TYPE;
 	private static final Schema.SObjectType OPPORTUNITY_OBJECT_TYPE;
+    private static final Schema.SobjectType GROUP_OBJECT_TYPE;
+    private static final Sobject[] GROUP_RECORDS;
 	
 	static
 	{
@@ -45,6 +47,7 @@ public class fflib_MatcherDefinitionsTest
 
 		ACCOUNT_OBJECT_TYPE = globalDescribe.get('Account');
 		OPPORTUNITY_OBJECT_TYPE = globalDescribe.get('Opportunity');
+        GROUP_OBJECT_TYPE = globalDescribe.get('Group');
 		
 		SObject accountRecord = ACCOUNT_OBJECT_TYPE.newSObject();
 		accountRecord.put('Name', 'MatcherDefinitionTestAccount' + System.now());
@@ -53,6 +56,13 @@ public class fflib_MatcherDefinitionsTest
 		Id accountId = accountRecord.Id;
 
 		ACCOUNT_RECORD = Database.query('SELECT Id, Name FROM Account WHERE Id = :accountId LIMIT 1');
+        
+        GROUP_RECORDS = new list<Group> {
+            new Group(Name = 'MatcherDefnTestGroup0'+System.now(), DeveloperName='MatcherDefnTestGroup0'+System.now().getTime(),Type='Queue'),
+            new Group(Name = 'MatcherDefnTestGroup1'+System.now(), DeveloperName='MatcherDefnTestGroup1'+System.now().getTime(),Type='Queue')
+        };
+        insert GROUP_RECORDS;    
+        
 	}
 
 	@isTest
@@ -890,6 +900,124 @@ public class fflib_MatcherDefinitionsTest
 		System.assert(matcher.matches(ACCOUNT_RECORD));
 
 		System.assert(!new fflib_MatcherDefinitions.SObjectWith(notQueriedFieldValues).matches(ACCOUNT_RECORD));
+	}
+
+	@isTest
+	private static void whenSObjectsWithInOrderMatchesShouldReturnCorrectResults()
+	{
+		Map<String, Schema.SObjectField> fields = GROUP_OBJECT_TYPE.getDescribe().fields.getMap();
+		Schema.SObjectField idField = fields.get('Id');
+		Schema.SObjectField nameField = fields.get('Name');
+		Schema.SObjectField createdDateField = fields.get('CreatedDate');
+		
+		list<Map<Schema.SObjectField, Object>> queriedFieldValues = new list<Map<Schema.SObjectField, Object>>
+		{
+            new map<Schema.SObjectField,Object> 
+            {
+                idField => GROUP_RECORDS[0].Id,
+				nameField => GROUP_RECORDS[0].get('Name')
+            },
+            new map<Schema.SObjectField,Object> 
+            {
+                idField => GROUP_RECORDS[1].Id,
+				nameField => GROUP_RECORDS[1].get('Name')
+            }               
+		};
+
+		list<Map<Schema.SObjectField, Object>> notQueriedFieldValues = new list<Map<Schema.SObjectField, Object>>
+		{
+			new map<Schema.SObjectField,Object> 
+            {
+                createdDateField => System.now()
+            },
+            new map<Schema.SObjectField,Object> 
+            {
+                createdDateField => System.now()
+            }    
+		};
+
+		fflib_IMatcher matcher = new fflib_MatcherDefinitions.SObjectsWith(queriedFieldValues);
+		
+		System.assert(!matcher.matches(null));
+		System.assert(!matcher.matches(new list<SObject>
+                                       {
+                                           OPPORTUNITY_OBJECT_TYPE.newSObject(),
+                                           OPPORTUNITY_OBJECT_TYPE.newSObject()    
+                                       }
+                                      ));
+		System.assert(!matcher.matches(new list<SObject>
+                                       {
+                                           GROUP_OBJECT_TYPE.newSObject(),
+                                           GROUP_OBJECT_TYPE.newSObject()
+                                       }
+                                      ),'sObjectsWith arity agrees but arg doesn\'t');
+		System.assert(!matcher.matches('NotAListofSObject'));
+
+		System.assert(matcher.matches(GROUP_RECORDS),'toMatch and args have same arity and in same order');
+        System.assert (!matcher.matches(new list<SObject> {GROUP_RECORDS[1],GROUP_RECORDS[0]}),
+                                     'sObjectsWith toMatch and args have same arity but args are in different order than toMatch') ;            
+                      
+
+		System.assert(!new fflib_MatcherDefinitions.SObjectsWith(notQueriedFieldValues).matches(GROUP_RECORDS));
+	}
+
+    @isTest
+	private static void whenSObjectsInAnyOrderWithMatchesShouldReturnCorrectResults()
+	{
+		Map<String, Schema.SObjectField> fields = GROUP_OBJECT_TYPE.getDescribe().fields.getMap();
+		Schema.SObjectField idField = fields.get('Id');
+		Schema.SObjectField nameField = fields.get('Name');
+		Schema.SObjectField createdDateField = fields.get('CreatedDate');
+		
+		list<Map<Schema.SObjectField, Object>> queriedFieldValues = new list<Map<Schema.SObjectField, Object>>
+		{
+            new map<Schema.SObjectField,Object> 
+            {
+                idField => GROUP_RECORDS[0].Id,
+				nameField => GROUP_RECORDS[0].get('Name')
+            },
+            new map<Schema.SObjectField,Object> 
+            {
+                idField => GROUP_RECORDS[1].Id,
+				nameField => GROUP_RECORDS[1].get('Name')
+            }               
+		};
+
+		list<Map<Schema.SObjectField, Object>> notQueriedFieldValues = new list<Map<Schema.SObjectField, Object>>
+		{
+			new map<Schema.SObjectField,Object> 
+            {
+                createdDateField => System.now()
+            },
+            new map<Schema.SObjectField,Object> 
+            {
+                createdDateField => System.now()
+            }    
+		};
+
+		fflib_IMatcher matcher = new fflib_MatcherDefinitions.SObjectsWith(queriedFieldValues,false); // any order
+		
+		System.assert(!matcher.matches(null));
+		System.assert(!matcher.matches(new list<SObject>
+                                       {
+                                           OPPORTUNITY_OBJECT_TYPE.newSObject(),
+                                           OPPORTUNITY_OBJECT_TYPE.newSObject()    
+                                       }
+                                      ));
+		System.assert(!matcher.matches(new list<SObject>
+                                       {
+                                           GROUP_OBJECT_TYPE.newSObject(),
+                                           GROUP_OBJECT_TYPE.newSObject()
+                                       }
+                                      ),'sObjectsWith arity agrees but arg doesn\'t match matcher');
+		System.assert(!matcher.matches('NotAListofSObject'));
+
+		System.assert(matcher.matches(GROUP_RECORDS),'toMatch and args have same arity and in same order. Match should be OK');
+        System.assert (matcher.matches(new list<SObject> {GROUP_RECORDS[1],GROUP_RECORDS[0]}),
+                                     'sObjectsWith toMatch and args have same arity but args are in diff order than matcher. Should be OK') ;            
+                      
+
+		System.assert(!new fflib_MatcherDefinitions.SObjectsWith(notQueriedFieldValues,false).matches(GROUP_RECORDS));
 	}
 
 	@isTest


### PR DESCRIPTION
Issue [Matcher sObjectWith doesn't work with uow.registerXXX(list)](https://github.com/financialforcedev/fflib-apex-mocks/issues/53)

**Premise**

uow.registerXXX can accept lists but there is no Matcher that can compare a list of `map<Schema.SobjectField,Object>` to the list of sobjects passed to the `uow.RegisterXXX(someList)` call in a mocked uow.  Helps avoid syntactically messy/clunky ArgumentCaptor in many cases. 

**Addition**

new MatcherDefinition `sObjectsWith`

_Two flavors:_

    fflib_Match.sObjectsWith(list<map<Schema.SobjectField,Object>> toMatch) 

each element in the toMatch list is compared against the sobjects passed to the mocked method. toMatch[i} is compared _only_ against sobject argument[i].

Arity of arguments and matcher field maps must be same, otherwise match is false.



    fflib_Match.sObjectsWith(list<map<Schema.SobjectField,Object>> toMatch, Boolean matchInOrder) 

When `matchInorder = false`, each sobject argument is compared against all of the matcher field maps.  Every argument must be matched to exactly one matcher field map and no matcher field map can match more than one sobject argument.

Arity of arguments and matcher field maps must be same, otherwise match is false

_Of course, not limited to just mocking fflib_UnitOfWork methods, any mocked method passed a list of Sobjects can be verified_

